### PR TITLE
Remove snackbar closing

### DIFF
--- a/hooks/useSnackbar.ts
+++ b/hooks/useSnackbar.ts
@@ -1,13 +1,9 @@
-import { ReactNode, useEffect } from 'react'
-import { useNavigator, useSafeContext } from '.'
+import { ReactNode } from 'react'
+import { useSafeContext } from '.'
 import * as Contexts from '../contexts'
 
 export function useSnackbar() {
   let snackbar = useSafeContext(Contexts.Snackbar)
-  let navigator = useNavigator()
-
-  // Закрывает снэкбар при переходе на другое состояние навигации
-  useEffect(() => navigator.createTask(snackbar.close), [])
 
   return {
     setSnackbar: (node: ReactNode) => snackbar.set(node),


### PR DESCRIPTION
Такие дела. Раньше снэкбар закрывался самостоятельно, и этот процесс нельзя было контролировать. Принимать опции для снэкбара пока не буду, реализовать старое поведение можно со своей стороны.

```jsx
import {useSnackbar} from '@unexp/router'

export function Info() {
  let {setSnackbar, closeSnackbar} = useSnackbar();
  
  /** Закрывает снэкбар при переходе на другую панель */
  useEffect(() => closeSnackbar, [])

  return <>
    ...
  </>
}
```